### PR TITLE
Refactor FredderslyPLD opener logic and remove Johann Shield Lob pull

### DIFF
--- a/RotationSolver/ExtraRotations/Tank/FredderslyPLD.cs
+++ b/RotationSolver/ExtraRotations/Tank/FredderslyPLD.cs
@@ -1,4 +1,4 @@
-// FredderslyPLD Test Version: 2026-07-01.2-StandardOpener
+// FredderslyPLD Test Version: 2026-07-01.3-ScrapLobPull
 
 namespace RotationSolver.ExtraRotations.Tank;
 
@@ -12,9 +12,7 @@ public sealed class FredderslyPLD : PaladinRotation
 	private static bool InConfiteorCombo => BladeOfFaithReady || BladeOfTruthReady || BladeOfValorReady;
 	private static bool HasJohannBurstGCD => HasConfiteorReady || InConfiteorCombo;
 
-	private bool CanUseJohannPullFightOrFlight => UseJohannShieldLobPull
-		&& CombatElapsedLessGCD(2);
-	private bool CanUseFightOrFlight => HasHostilesInRange || !MeleeFoF || CanUseJohannPullFightOrFlight;
+	private bool CanUseFightOrFlight => HasHostilesInRange || !MeleeFoF;
 	private bool IsStartingFightOrFlight => HasFightOrFlight || IsLastAbility(true, FightOrFlightPvE);
 
 	private bool FightOrFlightSoon => !HasFightOrFlight
@@ -60,9 +58,6 @@ public sealed class FredderslyPLD : PaladinRotation
 	#endregion
 
 	#region Config Options
-
-	[RotationConfig(CombatType.PvE, Name = "Use Shield Lob to pull like Johann")]
-	private bool UseJohannShieldLobPull { get; set; } = true;
 
 	[RotationConfig(CombatType.PvE, Name = "Only use Fight or Flight while in melee range of an enemy")]
 	public bool MeleeFoF { get; set; } = true;
@@ -145,24 +140,7 @@ public sealed class FredderslyPLD : PaladinRotation
 			return act;
 		}
 
-		if (UseJohannShieldLobPull && remainTime <= 3f && remainTime > 1f && UseBurstMedicine(out act))
-		{
-			return act;
-		}
-
-		if (UseJohannShieldLobPull && remainTime <= 1.5f && ShieldLobPvE.CanUse(out act))
-		{
-			return act;
-		}
-
-		// Shield Lob is a MeleeRangedAttack special type and refuses targets closer than
-		// 3y + MeleeRangedOffset, so fall back to Fast Blade when already in melee range.
-		if (UseJohannShieldLobPull && remainTime <= 0.58f && FastBladePvE.CanUse(out act))
-		{
-			return act;
-		}
-
-		if (!UseJohannShieldLobPull && remainTime < HolySpiritPvE.Info.CastTime + CountDownAhead
+		if (remainTime < HolySpiritPvE.Info.CastTime + CountDownAhead
 			&& HolySpiritPvE.CanUse(out act))
 		{
 			return act;
@@ -551,7 +529,7 @@ public sealed class FredderslyPLD : PaladinRotation
 		}
 
 		// Standard opener pots in Riot Blade's weave slot, two GCDs before Fight or Flight.
-		if (!UseJohannShieldLobPull && CombatElapsedLessGCD(3) && IsLastGCD(true, RiotBladePvE)
+		if (CombatElapsedLessGCD(3) && IsLastGCD(true, RiotBladePvE)
 			&& UseBurstMedicine(out act))
 		{
 			return true;
@@ -653,11 +631,11 @@ public sealed class FredderslyPLD : PaladinRotation
 			return false;
 		}
 
-		// Standard opener (no Shield Lob pull) holds Fight or Flight through the first
-		// combo GCDs; the final gate then fires it in Royal Authority's weave slot.
+		// Standard opener holds Fight or Flight through the first combo GCDs;
+		// the final gate then fires it in Royal Authority's weave slot.
 		if (CombatElapsedLessGCD(2))
 		{
-			return UseJohannShieldLobPull && CanUseJohannPullFightOrFlight;
+			return false;
 		}
 
 		if (!FastBladePvE.IsEnabled)

--- a/RotationSolver/ExtraRotations/Tank/FredderslyPLD.cs
+++ b/RotationSolver/ExtraRotations/Tank/FredderslyPLD.cs
@@ -1,4 +1,4 @@
-// FredderslyPLD Test Version: 2026-07-01.1-CountdownPullFallback
+// FredderslyPLD Test Version: 2026-07-01.2-StandardOpener
 
 namespace RotationSolver.ExtraRotations.Tank;
 
@@ -545,9 +545,19 @@ public sealed class FredderslyPLD : PaladinRotation
 	private bool TryUseJohannPotion(out IAction? act)
 	{
 		act = null;
-		return InCombat
-			&& HasFightOrFlight
-			&& UseBurstMedicine(out act);
+		if (!InCombat)
+		{
+			return false;
+		}
+
+		// Standard opener pots in Riot Blade's weave slot, two GCDs before Fight or Flight.
+		if (!UseJohannShieldLobPull && CombatElapsedLessGCD(3) && IsLastGCD(true, RiotBladePvE)
+			&& UseBurstMedicine(out act))
+		{
+			return true;
+		}
+
+		return HasFightOrFlight && UseBurstMedicine(out act);
 	}
 
 	private bool TryUseFightOrFlight(IAction nextGCD, out IAction? act)
@@ -643,9 +653,11 @@ public sealed class FredderslyPLD : PaladinRotation
 			return false;
 		}
 
+		// Standard opener (no Shield Lob pull) holds Fight or Flight through the first
+		// combo GCDs; the final gate then fires it in Royal Authority's weave slot.
 		if (CombatElapsedLessGCD(2))
 		{
-			return UseJohannShieldLobPull ? CanUseJohannPullFightOrFlight : HasHostilesInRange;
+			return UseJohannShieldLobPull && CanUseJohannPullFightOrFlight;
 		}
 
 		if (!FastBladePvE.IsEnabled)
@@ -673,7 +685,9 @@ public sealed class FredderslyPLD : PaladinRotation
 			return nextGCD.IsTheSameTo(true, RoyalAuthorityPvE, ProminencePvE);
 		}
 
-		return ImperatorPvE.Cooldown.WillHaveOneChargeGCD(1)
+		// IsCoolingDown guard: a never-used Imperator "will have a charge" too, which would
+		// fire Fight or Flight before Royal Authority banks procs in the standard opener.
+		return (ImperatorPvE.Cooldown.IsCoolingDown && ImperatorPvE.Cooldown.WillHaveOneChargeGCD(1))
 			|| HasJohannBurstGCD
 			|| StatusHelper.PlayerHasStatus(true, StatusID.AtonementReady, StatusID.SepulchreReady, StatusID.SupplicationReady, StatusID.DivineMight)
 			|| IsLastAction(true, RoyalAuthorityPvE)

--- a/RotationSolver/ExtraRotations/Tank/FredderslyPLD.cs
+++ b/RotationSolver/ExtraRotations/Tank/FredderslyPLD.cs
@@ -1,4 +1,4 @@
-// FredderslyPLD Test Version: 2026-06-29.3-OathDeadlock
+// FredderslyPLD Test Version: 2026-07-01.1-CountdownPullFallback
 
 namespace RotationSolver.ExtraRotations.Tank;
 
@@ -11,11 +11,6 @@ public sealed class FredderslyPLD : PaladinRotation
 
 	private static bool InConfiteorCombo => BladeOfFaithReady || BladeOfTruthReady || BladeOfValorReady;
 	private static bool HasJohannBurstGCD => HasConfiteorReady || InConfiteorCombo;
-
-	private bool JustUsedOath => IsLastAbility(true, HolySheltronPvE)
-		|| IsLastAbility(true, SheltronPvE)
-		|| IsLastAbility(true, InterventionPvE)
-		|| IsLastAbility(true, CoverPvE);
 
 	private bool CanUseJohannPullFightOrFlight => UseJohannShieldLobPull
 		&& CombatElapsedLessGCD(2);
@@ -156,6 +151,13 @@ public sealed class FredderslyPLD : PaladinRotation
 		}
 
 		if (UseJohannShieldLobPull && remainTime <= 1.5f && ShieldLobPvE.CanUse(out act))
+		{
+			return act;
+		}
+
+		// Shield Lob is a MeleeRangedAttack special type and refuses targets closer than
+		// 3y + MeleeRangedOffset, so fall back to Fast Blade when already in melee range.
+		if (UseJohannShieldLobPull && remainTime <= 0.58f && FastBladePvE.CanUse(out act))
 		{
 			return act;
 		}


### PR DESCRIPTION
## Summary
This PR refactors the FredderslyPLD rotation's opener sequence and removes the optional "Johann Shield Lob pull" feature. The changes simplify the pre-combat and early combat logic while improving the standard opener's reliability.

## Key Changes
- **Removed Johann Shield Lob pull configuration**: Deleted the `UseJohannShieldLobPull` config option and all associated conditional logic that branched between two different pull strategies
- **Simplified Fight or Flight usage**: Removed the `CanUseJohannPullFightOrFlight` condition and now `CanUseFightOrFlight` only checks for hostile range or melee range requirement
- **Refactored pre-combat rotation**: Removed Shield Lob and burst medicine usage during countdown, now only uses Holy Spirit as the pre-pull ability
- **Improved potion timing**: Changed `TryUseJohannPotion` to use potions during Riot Blade's weave slot (two GCDs before Fight or Flight) in the standard opener, rather than simply when Fight or Flight is available
- **Fixed Fight or Flight opener gate**: Updated `ShouldUseFightOrFlight` to return `false` during the first 2 GCDs of combat (standard opener holds FoF through initial combo), and added a guard to check `ImperatorPvE.Cooldown.IsCoolingDown` before checking charge availability to prevent premature FoF usage
- **Added clarifying comments**: Included comments explaining the standard opener's Fight or Flight timing and the Imperator cooldown guard logic

## Notable Implementation Details
- The standard opener now follows a consistent pattern: potions in Riot Blade's weave slot → Fight or Flight fires in Royal Authority's weave slot
- The Imperator cooldown guard prevents Fight or Flight from firing before the rotation has banked procs in the standard opener
- All pull-specific branching logic has been consolidated into a single, simpler code path