### PR TITLE
FredderslyPLD: standard opener, burst timing fixes, and cleanup

### DIFF
--- a/RotationSolver/ExtraRotations/Tank/FredderslyPLD.cs
+++ b/RotationSolver/ExtraRotations/Tank/FredderslyPLD.cs
@@ -1,4 +1,4 @@
-// FredderslyPLD Test Version: 2026-07-01.2-StandardOpener
+// FredderslyPLD Test Version: 2026-07-01.3-ScrapLobPull
 
 namespace RotationSolver.ExtraRotations.Tank;
 
@@ -12,9 +12,7 @@ public sealed class FredderslyPLD : PaladinRotation
 	private static bool InConfiteorCombo => BladeOfFaithReady || BladeOfTruthReady || BladeOfValorReady;
 	private static bool HasJohannBurstGCD => HasConfiteorReady || InConfiteorCombo;
 
-	private bool CanUseJohannPullFightOrFlight => UseJohannShieldLobPull
-		&& CombatElapsedLessGCD(2);
-	private bool CanUseFightOrFlight => HasHostilesInRange || !MeleeFoF || CanUseJohannPullFightOrFlight;
+	private bool CanUseFightOrFlight => HasHostilesInRange || !MeleeFoF;
 	private bool IsStartingFightOrFlight => HasFightOrFlight || IsLastAbility(true, FightOrFlightPvE);
 
 	private bool FightOrFlightSoon => !HasFightOrFlight
@@ -60,9 +58,6 @@ public sealed class FredderslyPLD : PaladinRotation
 	#endregion
 
 	#region Config Options
-
-	[RotationConfig(CombatType.PvE, Name = "Use Shield Lob to pull like Johann")]
-	private bool UseJohannShieldLobPull { get; set; } = true;
 
 	[RotationConfig(CombatType.PvE, Name = "Only use Fight or Flight while in melee range of an enemy")]
 	public bool MeleeFoF { get; set; } = true;
@@ -145,24 +140,7 @@ public sealed class FredderslyPLD : PaladinRotation
 			return act;
 		}
 
-		if (UseJohannShieldLobPull && remainTime <= 3f && remainTime > 1f && UseBurstMedicine(out act))
-		{
-			return act;
-		}
-
-		if (UseJohannShieldLobPull && remainTime <= 1.5f && ShieldLobPvE.CanUse(out act))
-		{
-			return act;
-		}
-
-		// Shield Lob is a MeleeRangedAttack special type and refuses targets closer than
-		// 3y + MeleeRangedOffset, so fall back to Fast Blade when already in melee range.
-		if (UseJohannShieldLobPull && remainTime <= 0.58f && FastBladePvE.CanUse(out act))
-		{
-			return act;
-		}
-
-		if (!UseJohannShieldLobPull && remainTime < HolySpiritPvE.Info.CastTime + CountDownAhead
+		if (remainTime < HolySpiritPvE.Info.CastTime + CountDownAhead
 			&& HolySpiritPvE.CanUse(out act))
 		{
 			return act;
@@ -551,7 +529,7 @@ public sealed class FredderslyPLD : PaladinRotation
 		}
 
 		// Standard opener pots in Riot Blade's weave slot, two GCDs before Fight or Flight.
-		if (!UseJohannShieldLobPull && CombatElapsedLessGCD(3) && IsLastGCD(true, RiotBladePvE)
+		if (CombatElapsedLessGCD(3) && IsLastGCD(true, RiotBladePvE)
 			&& UseBurstMedicine(out act))
 		{
 			return true;
@@ -653,11 +631,11 @@ public sealed class FredderslyPLD : PaladinRotation
 			return false;
 		}
 
-		// Standard opener (no Shield Lob pull) holds Fight or Flight through the first
-		// combo GCDs; the final gate then fires it in Royal Authority's weave slot.
+		// Standard opener holds Fight or Flight through the first combo GCDs;
+		// the final gate then fires it in Royal Authority's weave slot.
 		if (CombatElapsedLessGCD(2))
 		{
-			return UseJohannShieldLobPull && CanUseJohannPullFightOrFlight;
+			return false;
 		}
 
 		if (!FastBladePvE.IsEnabled)

--- a/RotationSolver/ExtraRotations/Tank/FredderslyPLD.cs
+++ b/RotationSolver/ExtraRotations/Tank/FredderslyPLD.cs
@@ -1,4 +1,4 @@
-// FredderslyPLD Test Version: 2026-07-01.1-CountdownPullFallback
+// FredderslyPLD Test Version: 2026-07-01.2-StandardOpener
 
 namespace RotationSolver.ExtraRotations.Tank;
 
@@ -545,9 +545,19 @@ public sealed class FredderslyPLD : PaladinRotation
 	private bool TryUseJohannPotion(out IAction? act)
 	{
 		act = null;
-		return InCombat
-			&& HasFightOrFlight
-			&& UseBurstMedicine(out act);
+		if (!InCombat)
+		{
+			return false;
+		}
+
+		// Standard opener pots in Riot Blade's weave slot, two GCDs before Fight or Flight.
+		if (!UseJohannShieldLobPull && CombatElapsedLessGCD(3) && IsLastGCD(true, RiotBladePvE)
+			&& UseBurstMedicine(out act))
+		{
+			return true;
+		}
+
+		return HasFightOrFlight && UseBurstMedicine(out act);
 	}
 
 	private bool TryUseFightOrFlight(IAction nextGCD, out IAction? act)
@@ -643,9 +653,11 @@ public sealed class FredderslyPLD : PaladinRotation
 			return false;
 		}
 
+		// Standard opener (no Shield Lob pull) holds Fight or Flight through the first
+		// combo GCDs; the final gate then fires it in Royal Authority's weave slot.
 		if (CombatElapsedLessGCD(2))
 		{
-			return UseJohannShieldLobPull ? CanUseJohannPullFightOrFlight : HasHostilesInRange;
+			return UseJohannShieldLobPull && CanUseJohannPullFightOrFlight;
 		}
 
 		if (!FastBladePvE.IsEnabled)
@@ -673,7 +685,9 @@ public sealed class FredderslyPLD : PaladinRotation
 			return nextGCD.IsTheSameTo(true, RoyalAuthorityPvE, ProminencePvE);
 		}
 
-		return ImperatorPvE.Cooldown.WillHaveOneChargeGCD(1)
+		// IsCoolingDown guard: a never-used Imperator "will have a charge" too, which would
+		// fire Fight or Flight before Royal Authority banks procs in the standard opener.
+		return (ImperatorPvE.Cooldown.IsCoolingDown && ImperatorPvE.Cooldown.WillHaveOneChargeGCD(1))
 			|| HasJohannBurstGCD
 			|| StatusHelper.PlayerHasStatus(true, StatusID.AtonementReady, StatusID.SepulchreReady, StatusID.SupplicationReady, StatusID.DivineMight)
 			|| IsLastAction(true, RoyalAuthorityPvE)

--- a/RotationSolver/ExtraRotations/Tank/FredderslyPLD.cs
+++ b/RotationSolver/ExtraRotations/Tank/FredderslyPLD.cs
@@ -1,4 +1,4 @@
-// FredderslyPLD Test Version: 2026-06-29.3-OathDeadlock
+// FredderslyPLD Test Version: 2026-07-01.1-CountdownPullFallback
 
 namespace RotationSolver.ExtraRotations.Tank;
 
@@ -11,11 +11,6 @@ public sealed class FredderslyPLD : PaladinRotation
 
 	private static bool InConfiteorCombo => BladeOfFaithReady || BladeOfTruthReady || BladeOfValorReady;
 	private static bool HasJohannBurstGCD => HasConfiteorReady || InConfiteorCombo;
-
-	private bool JustUsedOath => IsLastAbility(true, HolySheltronPvE)
-		|| IsLastAbility(true, SheltronPvE)
-		|| IsLastAbility(true, InterventionPvE)
-		|| IsLastAbility(true, CoverPvE);
 
 	private bool CanUseJohannPullFightOrFlight => UseJohannShieldLobPull
 		&& CombatElapsedLessGCD(2);
@@ -156,6 +151,13 @@ public sealed class FredderslyPLD : PaladinRotation
 		}
 
 		if (UseJohannShieldLobPull && remainTime <= 1.5f && ShieldLobPvE.CanUse(out act))
+		{
+			return act;
+		}
+
+		// Shield Lob is a MeleeRangedAttack special type and refuses targets closer than
+		// 3y + MeleeRangedOffset, so fall back to Fast Blade when already in melee range.
+		if (UseJohannShieldLobPull && remainTime <= 0.58f && FastBladePvE.CanUse(out act))
 		{
 			return act;
 		}


### PR DESCRIPTION
## Summary

Reworks the FredderslyPLD opener to follow the standard Paladin opener (Holy Spirit precast, Fight or Flight in Royal Authority's weave slot) and removes the Shield Lob pull mode, validated against top Lindwurm Paladin logs.

## Changes

- **Standard opener as the only opener**: countdown now precasts Holy Spirit; the Shield Lob pull mode (`UseJohannShieldLobPull` config, countdown Shield Lob/pot branches, early Fight or Flight pull gate) is removed
- **Fight or Flight opener timing**: held through the first two combo GCDs so it fires in Royal Authority's weave slot with procs banked; added an `IsCoolingDown` guard to the Imperator alignment clause so a never-used Imperator does not trigger Fight or Flight early
- **Opener potion timing**: burst medicine now fires in Riot Blade's weave slot, two GCDs before Fight or Flight, matching the standard opener; mid-fight potions still align to Fight or Flight windows
- **Cleanup**: removed the unused `JustUsedOath` property left behind by an earlier fix

## Notes

- Burst window sequencing (Fight or Flight + Imperator double weave, Confiteor chain, Expiacion/Circle of Scorn alignment, Intervene spending) is unchanged
- Net: 7 insertions, 29 deletions in `RotationSolver/ExtraRotations/Tank/FredderslyPLD.cs` relative to the previous revision of the branch history; single file changed overall

Supersedes #1 (identical commits, renamed branch).

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8jrYdoEKq36dowqvttmyW)_