### PR TITLE
FredderslyPLD: fix combo break when Divine Might is held into a burst window

### DIFF
--- a/RotationSolver/ExtraRotations/Tank/FredderslyPLD.cs
+++ b/RotationSolver/ExtraRotations/Tank/FredderslyPLD.cs
@@ -1,4 +1,4 @@
-// FredderslyPLD Test Version: 2026-07-01.3-ScrapLobPull
+// FredderslyPLD Test Version: 2026-07-01.4-ComboBreakFix
 
 namespace RotationSolver.ExtraRotations.Tank;
 
@@ -44,13 +44,21 @@ public sealed class FredderslyPLD : PaladinRotation
 			&& (ImperatorPvE.EnoughLevel && ImperatorPvE.Cooldown.IsCoolingDown || !ImperatorPvE.EnoughLevel))
 		|| (!FightOrFlightPvE.Cooldown.IsCoolingDown && (!ImperatorPvE.EnoughLevel || !ImperatorPvE.Cooldown.IsCoolingDown));
 
+	// skipStatusProvideCheck: Royal Authority is status-blocked while Divine Might or
+	// Atonement Ready is up, so a plain CanUse can't tell us the combo is pending.
+	private bool RoyalAuthorityComboPending => RoyalAuthorityPvE.CanUse(out _, skipStatusProvideCheck: true, skipComboCheck: false)
+		|| RageOfHalonePvE.CanUse(out _, skipStatusProvideCheck: true, skipComboCheck: false);
+
 	private bool ShouldHoldAtonementForFightOrFlight => ShouldHoldForFightOrFlight(StatusID.AtonementReady)
-		&& !RoyalAuthorityPvE.CanUse(out _, skipComboCheck: false)
-		&& !RageOfHalonePvE.CanUse(out _, skipComboCheck: false);
+		&& !RoyalAuthorityComboPending;
 
 	private bool ShouldHoldSupplicationForFightOrFlight => ShouldHoldForFightOrFlight(StatusID.SupplicationReady);
 	private bool ShouldHoldSepulchreForFightOrFlight => ShouldHoldForFightOrFlight(StatusID.SepulchreReady);
-	private bool ShouldHoldDivineMightForFightOrFlight => ShouldHoldForFightOrFlight(StatusID.DivineMight);
+
+	// Released when Royal Authority is combo-pending: holding Divine Might would status-block
+	// Royal Authority and dead-end the combo into Fast Blade.
+	private bool ShouldHoldDivineMightForFightOrFlight => ShouldHoldForFightOrFlight(StatusID.DivineMight)
+		&& !RoyalAuthorityComboPending;
 	private bool ShouldSpendInterveneForDamage => HasFightOrFlight
 		&& InterveneChargesToSpendInFightOrFlight > 0
 		&& IntervenePvE.Cooldown.CurrentCharges > IntervenePvE.Cooldown.MaxCharges - InterveneChargesToSpendInFightOrFlight;
@@ -419,8 +427,7 @@ public sealed class FredderslyPLD : PaladinRotation
 	{
 		act = null;
 		if (HasFightOrFlight || StatusHelper.PlayerHasStatus(true, StatusID.Medicated)
-			|| RoyalAuthorityPvE.CanUse(out _, skipComboCheck: false)
-			|| RageOfHalonePvE.CanUse(out _, skipComboCheck: false)
+			|| RoyalAuthorityComboPending
 			|| TotalEclipsePvE.CanUse(out _))
 		{
 			return false;


### PR DESCRIPTION
## Summary

Fixes a combo break observed in live testing: with Fight or Flight about a second from ready, the rotation cast Riot Blade and then Fast Blade, resetting the melee combo and losing a Royal Authority.

## Root cause

Royal Authority has `StatusProvide = [DivineMight, AtonementReady]` in the base class, so `CanUse` returns false while either buff is up. This defeated two guards at once:

- `TryUseJohannComboDrift`'s Royal Authority bail-out could not see the combo was pending, so drift fired Fast Blade after Riot Blade
- the Divine Might hold kept Holy Spirit from spending the proc, which was the only thing keeping Royal Authority blocked

## Changes

- Add `RoyalAuthorityComboPending`, which checks Royal Authority / Rage of Halone with `skipStatusProvideCheck: true` so a pending combo is visible even while Divine Might or Atonement Ready is active
- Use it in the combo-drift bail-out and the Atonement hold (whose previous `CanUse` checks had the same blind spot)
- Release the Divine Might hold when the combo is pending, so Holy Spirit spends the proc one GCD before the window and Royal Authority slides into the burst with fresh procs

## Verification

Traced against the in-game capture: at the failure point the drift bail-out now triggers, the Divine Might hold releases, and the sequence becomes Riot Blade → Holy Spirit → Fight or Flight → Royal Authority inside the window — matching the reference logs' pre-window pattern.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8jrYdoEKq36dowqvttmyW)_